### PR TITLE
Keyword fixes

### DIFF
--- a/src/query/queryconfig.yml
+++ b/src/query/queryconfig.yml
@@ -2,7 +2,7 @@ weights:
   full_title: 1000
   partial_title: 100
 
-  keyword: 500
+  keyword: 50
 
   full_text: 100
   partial_text: 10

--- a/src/query/queryranker.py
+++ b/src/query/queryranker.py
@@ -1,4 +1,5 @@
 from query.queryconfig import QueryConfig
+import logging
 
 
 class QueryRanker:
@@ -31,7 +32,8 @@ class QueryRanker:
         return 0
 
     def __get_keyword_weight(self, card, query):
-        if query in [x.lower() for x in card.keywords.split()]:
+        keywords = [x.lower() for x in card.keywords.split()]
+        if set(query.split()) <= set(keywords):
             return self.__config.keyword_weight
         return 0
 


### PR DESCRIPTION
- Reduce weight of keywords they are broad categories like "code gate" and not typically what a user is looking to match.
- Compare split keywords vs individual words in query. This will match a  query "code gate sentry" to the keyword data "Sentry - Code Gate -Barrier" properly (see card Orion).